### PR TITLE
Ensured Environment Specification

### DIFF
--- a/lib/guard/unicorn.rb
+++ b/lib/guard/unicorn.rb
@@ -8,7 +8,7 @@ module Guard
     DEFAULT_PID_PATH    = File.join("tmp", "pids", "unicorn.pid")
     DEFAULT_CONFIG_PATH = File.join("config", "unicorn.rb")
     DEFAULT_PORT        = 3000
-    DEFAULT_ENVIRONMENT = Rails.env.to_s
+    DEFAULT_ENVIRONMENT = "development"
 
     # Initialize a Guard.
     # @param [Array<Guard::Watcher>] watchers the Guard file watchers


### PR DESCRIPTION
I had an issue where Unicorn kept running in a `test` environment when I wanted it to run in a `development` environment. I can't change in my `config/unicorn_guard.rb` so I figured I'd change it here.
