### PR TITLE
Making the unicorn command configurable

### DIFF
--- a/lib/guard/unicorn.rb
+++ b/lib/guard/unicorn.rb
@@ -9,6 +9,7 @@ module Guard
     DEFAULT_CONFIG_PATH = File.join("config", "unicorn.rb")
     DEFAULT_PORT        = 3000
     DEFAULT_ENVIRONMENT = "development"
+    DEFAULT_COMMAND = "unicorn_rails"
 
     # Initialize a Guard.
     # @param [Array<Guard::Watcher>] watchers the Guard file watchers
@@ -27,6 +28,7 @@ module Guard
       @port           = options.fetch(:port, DEFAULT_PORT)
       @environment    = options.fetch(:environment, DEFAULT_ENVIRONMENT)
       @socket         = options.fetch(:socket, nil)
+      @command        = options.fetch(:command, DEFAULT_COMMAND)
 
       super
     end
@@ -39,7 +41,7 @@ module Guard
 
       cmd = []
       cmd << "bundle exec" if @enable_bundler
-      cmd << "unicorn_rails"
+      cmd << @command
       cmd << "-c #{@config_file}"
       cmd << "-p #{@port}" unless @socket
       cmd << "-l #{@socket}" if @socket


### PR DESCRIPTION
As not everyone uses guard with rails (like me), hard coding the unicorn_rails command in this guard is not good. 

Here is a suggestion for fixing this without breaking the current default.


<!---
@huboard:{"order":14.0,"milestone_order":8,"custom_state":""}
-->
