### PR TITLE
Send both USR2 and QUIT to unicorn on restart.

### DIFF
--- a/lib/guard/unicorn.rb
+++ b/lib/guard/unicorn.rb
@@ -82,9 +82,17 @@ module Guard
       # For now, let's rely on the fact that the user does know how to write
       # a good unicorn configuration and he will have a block of code that
       # will properly handle `USR2` signals.
-      signal = @preloading ? "USR2" : "HUP"
-      ::Process.kill signal, pid
+      if @preloading
+        oldpid = pid
+        UI.debug "Sending USR2 to unicorn with pid #{oldpid}"
+        ::Process.kill 'USR2', oldpid
+        UI.debug "Sending QUIT to unicorn with pid #{oldpid}"
+        ::Process.kill 'QUIT', oldpid
+      else
+        ::Process.kill 'HUP', pid
+      end
 
+      UI.info "Done reloading unicorn."
       success "Unicorn reloaded"
     end
 


### PR DESCRIPTION
As per http://unicorn.bogomips.org/SIGNALS.html, both signals should be sent for a full restart.  I have tested this patch and, when used with livereload, it makes the browser reload after unicorn has begun restarting.  Otherwise, the page reloads before unicorn does and the page needs to be manually refreshed a second time.
