### PR TITLE
Fixed setting of PID when starting Unicorn

### DIFF
--- a/lib/guard/unicorn.rb
+++ b/lib/guard/unicorn.rb
@@ -46,9 +46,7 @@ module Guard
       cmd << "-E #{@environment}"
       cmd << "-D" if @run_as_daemon 
 
-      @pid = ::Process.fork do
-        system "#{cmd.join " "}"
-      end
+      @pid = spawn "#{cmd.join " "}"
 
       success "Unicorn started."
     end


### PR DESCRIPTION
From my experiences with my gem based on Guard::Unicorn, [Guard::Foreman](https://github.com/J3RN/guard-foreman), it seems that the block:

``` ruby
@pid = Process.fork do
  system "#{cmd.join " "}"
end
```

Will create a child process to run the `system` command, which will, in fact, create yet another child process. In order to truly get the PID of the `Unicorn` process, I changed this block to:

``` ruby
@pid = spawn "#{cmd.join " "}"
```
