### PR TITLE
Use "unicorn" instead of "unicorn_rails"

### DIFF
--- a/lib/guard/unicorn.rb
+++ b/lib/guard/unicorn.rb
@@ -38,7 +38,7 @@ module Guard
 
       cmd = []
       cmd << "bundle exec" if @enable_bundler
-      cmd << "unicorn_rails"
+      cmd << "unicorn"
       cmd << "-c #{@config_file}"
       cmd << "-p #{@port}" if @port
       cmd << "-l #{@socket}" if @socket


### PR DESCRIPTION
`unicorn_rails` doesn't play nicely with non-Rails apps (i.e. they don't boot). Its usage also seems to be discouraged: http://unicorn.bogomips.org/unicorn_rails_1.html

Would there be any breaking changes merging this?