### PR TITLE
Changed default 'unicorn_rails' to 'unicorn' and added it as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,5 @@ Available options:
 * `:pid_file` path to the Unicorn PID file. Defaults to `tmp/pids/unicorn.pid`
 * `:preloading` is Unicorn configured to preload the application? Defaults to
   `false`.
-* `:port` on what port to run Unicorn. Defaults to `3000`.
+* `:port` on what port to run Unicorn. Defaults to `8080`.
+* `:unicorn_rails` use `unicorn_rails` command instead of `unicorn`. [For ancient Rails versions.](http://unicorn.bogomips.org/README.html) Defaults to `false`.

--- a/lib/guard/unicorn.rb
+++ b/lib/guard/unicorn.rb
@@ -6,7 +6,7 @@ module Guard
     # Sensible defaults for Rails projects
     DEFAULT_PID_PATH    = File.join("tmp", "pids", "unicorn.pid")
     DEFAULT_CONFIG_PATH = File.join("config", "unicorn.rb")
-    DEFAULT_PORT        = 3000
+    DEFAULT_PORT        = 8080 # Unicorn defaults to 8080
     DEFAULT_ENVIRONMENT = "development"
 
     # Initialize a Guard.
@@ -26,6 +26,7 @@ module Guard
       @port           = options.fetch(:port, DEFAULT_PORT)
       @environment    = options.fetch(:environment, DEFAULT_ENVIRONMENT)
       @socket         = options.fetch(:socket, nil)
+      @unicorn_rails  = options.fetch(:unicorn_rails, false) 
 
       super
     end
@@ -38,7 +39,7 @@ module Guard
 
       cmd = []
       cmd << "bundle exec" if @enable_bundler
-      cmd << "unicorn_rails"
+      cmd << (@unicorn_rails ? 'unicorn_rails' : 'unicorn')
       cmd << "-c #{@config_file}"
       cmd << "-p #{@port}" if @port
       cmd << "-l #{@socket}" if @socket


### PR DESCRIPTION
So I've seen there is a PR changing `unicorn_rails` to `unicorn`. I did the same but I also added the `unicorn_rails` as an option if somebody still uses it but basically this change is code-breaking since `unicorn_rails` sets `RAILS_ENV` and `unicorn` sets `RACK_ENV`.

Also I changed the default port to unicorn's default 8080.
